### PR TITLE
Update To Python 3.8 and 3.9, drop support for everything below

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,20 @@
 # Use Python
 language: python
 
-# Run the test runner using the same version of Python we use.
-python: 3.5
+matrix:
+  include:
+    - python: 3.8
+      env: TOX_ENV=py38
+    - python: 3.9
+      env: TOX_ENV=py39
+    - python: 3.9
+      env: TOX_ENV=docs
+    - python: 3.9
+      env: TOX_ENV=pep8
 
 # Install the test runner.
 install: pip install tox
-
-# Run each environment separately so we get errors back from all of them.
-env:
-  - TOX_ENV=py35
-  - TOX_ENV=py34
-  - TOX_ENV=pep8
-  - TOX_ENV=docs
-script:
-  - tox -e $TOX_ENV
+script: tox -e $TOX_ENV
 
 # Control the branches that get built.
 branches:

--- a/henson_sentry.py
+++ b/henson_sentry.py
@@ -1,6 +1,5 @@
 """A Henson plugin to integrate Sentry."""
 
-import asyncio
 import os as _os
 import pkg_resources as _pkg_resources
 
@@ -67,26 +66,22 @@ class Sentry(Extension):
         app.error(self._handle_exception)
         app.message_acknowledgement(self._after_message)
 
-    @asyncio.coroutine
-    def capture_exception(self, exc_info=None, **kwargs):
+    async def capture_exception(self, exc_info=None, **kwargs):
         """Create an event from an exception."""
         self._client.captureException(exc_info, **kwargs)
 
-    @asyncio.coroutine
-    def capture_message(self, message, **kwargs):
+    async def capture_message(self, message, **kwargs):
         """Create an event from ``message``."""
         self._client.captureMessage(message, **kwargs)
 
-    @asyncio.coroutine
-    def _after_message(self, app, message):
+    async def _after_message(self, app, message):
         self._client.context.clear()
 
-    @asyncio.coroutine
-    def _handle_exception(self, app, message, exc):
+    async def _handle_exception(self, app, message, exc):
         if isinstance(exc, self.app.settings['RAVEN_IGNORE_EXCEPTIONS']):
             return
 
-        yield from self.capture_exception(message=message)
+        await self.capture_exception(message=message)
 
 
 def _make_client(app):

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,8 @@ def read(filename):
 setup(
     name='Henson-Sentry',
     version='0.4.0',
-    author='Andy Dirnberger',
-    author_email='andy@dirnberger.me',
+    author='Andy Dirnberger, Leonard Bedner, and others',
+    author_email='henson@iheart.com',
     url='https://henson-sentry.readthedocs.io',
     description='A library for integrating Sentry into a Henson application',
     long_description=read('README.rst'),
@@ -46,8 +46,8 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3 :: Only',
         'Topic :: Software Development',
     ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,8 +22,7 @@ class MockClient(Client):
 
 
 class MockConsumer:
-    @asyncio.coroutine
-    def read(self):
+    async def read(self):
         return 1
 
 
@@ -57,16 +56,14 @@ def sentry(test_client, test_app):
 @pytest.fixture
 def test_app(test_consumer, event_loop):
     """Return a test application."""
-    @asyncio.coroutine
-    def callback(app, message):
+    async def callback(app, message):
         raise Exception('testing')
 
     app = Application('testing', callback=callback, consumer=test_consumer)
     app.settings['SENTRY_DSN'] = 'testing'
 
     @app.message_acknowledgement
-    @asyncio.coroutine
-    def stop_loop(app, message):
+    async def stop_loop(app, message):
         event_loop.stop()
 
     return app

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -1,19 +1,16 @@
 """Test Henson-Sentry."""
 
-import asyncio
-
 from henson_sentry import Sentry
 
 
 def test_capture_exception(sentry, test_app, event_loop, cancelled_future,
                            queue):
     """Test capture_exception."""
-    @asyncio.coroutine
-    def callback(app, message):
+    async def callback(app, message):
         try:
             1 / 0
         except:
-            yield from sentry.capture_exception()
+            await sentry.capture_exception()
     test_app.callback = callback
 
     event_loop.run_until_complete(
@@ -25,9 +22,8 @@ def test_capture_exception(sentry, test_app, event_loop, cancelled_future,
 def test_capture_message(sentry, test_app, event_loop, cancelled_future,
                          queue):
     """Test capture_message."""
-    @asyncio.coroutine
-    def callback(app, message):
-        yield from sentry.capture_message(message)
+    async def callback(app, message):
+        await sentry.capture_message(message)
     test_app.callback = callback
 
     event_loop.run_until_complete(

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = docs,pep8,py34,py35
+envlist = docs,pep8,py38,py39
 
 [testenv]
 deps =
@@ -7,18 +7,18 @@ deps =
     pytest
     pytest-asyncio
 commands =
-    python -m coverage run -m pytest --strict {posargs: tests}
+    python -m coverage run -m pytest --strict-markers {posargs: tests}
     python -m coverage report -m --include="henson_sentry.py"
 
 [testenv:docs]
-basepython = python3.5
+basepython = python3.9
 deps = -rdocs-requirements.txt
 commands =
     sphinx-build -W -b html -d {envtmpdir}/doctrees docs docs/_build/html
     doc8 --allow-long-titles README.rst docs/ --ignore-path docs/_build/
 
 [testenv:pep8]
-basepython = python3.5
+basepython = python3.9
 skip_install = True
 deps =
     flake8-docstrings


### PR DESCRIPTION
- forked from [dirn/Henson-Sentry](https://github.com/dirn/Henson-Sentry)
- remove support for Python <= 3.7
- add support for Python >= 3.8
- stopped using `@asyncio.coroutine`, added `async` to all appropriate methods, since the former is deprecated
- replaced `yield from` -> `await` where applicable, since the former is deprecated

***NOTE:*** We should probably look at swapping out `raven-aiohttp` for `sentry-python`, as the latter supports asynchronous functionality, and the former hasn't been updated in 3 years, and is using deprecated decorators (`@coroutine`) that will most likely be removed at some point.